### PR TITLE
Add setContinuousMode()

### DIFF
--- a/src/BMI270.cpp
+++ b/src/BMI270.cpp
@@ -75,6 +75,17 @@ int BoschSensorClass::begin() {
   _initialized = true;
 }
 
+
+void BoschSensorClass::setContinuousMode() {
+  bmi2_set_fifo_config(BMI2_FIFO_GYR_EN | BMI2_FIFO_ACC_EN, 1, &bmi2);
+  continuousMode = true;
+}
+
+void BoschSensorClass::oneShotMode() {
+  bmi2_set_fifo_config(BMI2_FIFO_GYR_EN | BMI2_FIFO_ACC_EN, 0, &bmi2);
+  continuousMode = false;
+}
+
 // Accelerometer
 int BoschSensorClass::readAcceleration(float& x, float& y, float& z) {
   struct bmi2_sens_data sensor_data;

--- a/src/BoschSensorClass.h
+++ b/src/BoschSensorClass.h
@@ -32,6 +32,9 @@ class BoschSensorClass {
     BoschSensorClass(TwoWire& wire = Wire);
     ~BoschSensorClass() {}
 
+    void setContinuousMode();
+    void oneShotMode();
+
     int begin();
     void end();
 
@@ -88,6 +91,8 @@ class BoschSensorClass {
     struct bmi2_dev bmi2;
     struct bmm150_dev bmm1;
     uint16_t _int_status;
+  private:
+    bool continuousMode;
 };
 
 extern BoschSensorClass IMU_BMI270_BMM150;


### PR DESCRIPTION
- Add the setContinuousMode() and oneShotMode() methods that enables/disables FIFO
- Example compiles.
- Tested with [TensorFlow magic wand examples](https://github.com/tensorflow/tflite-micro-arduino-examples/tree/main/examples/magic_wand) but does **not work**.  