### PR TITLE
Fix: no need for arduino::stream.

### DIFF
--- a/src/BoschSensorClass.h
+++ b/src/BoschSensorClass.h
@@ -38,7 +38,7 @@ class BoschSensorClass {
     int begin();
     void end();
 
-    void debug(arduino::Stream&);
+    void debug(Stream&);
     #ifdef __MBED__
     void onInterrupt(mbed::Callback<void()>);
     void setInterruptPin(PinName irq_pin) {


### PR DESCRIPTION
Enables build on ESP32 core.