### PR TITLE
Fix: The right unit for a sample rate is Hz, not µT,

### DIFF
--- a/examples/SimpleMagnetometer/SimpleMagnetometer.ino
+++ b/examples/SimpleMagnetometer/SimpleMagnetometer.ino
@@ -27,7 +27,7 @@ void setup() {
   }
   Serial.print("Magnetic field sample rate = ");
   Serial.print(IMU.magneticFieldSampleRate());
-  Serial.println(" uT");
+  Serial.println(" Hz");
   Serial.println();
   Serial.println("Magnetic Field in uT");
   Serial.println("X\tY\tZ");


### PR DESCRIPTION
Tesla, or µTesla are for magnetic flux density. This is simply a error in textual output, not functionality.

This fixes #23.