### PR TITLE
Fix: remove function definition for not implemented function "getTemperature".

### DIFF
--- a/src/BoschSensorClass.h
+++ b/src/BoschSensorClass.h
@@ -64,8 +64,6 @@ class BoschSensorClass {
     virtual int magneticFieldAvailable(); // Number of samples in the FIFO.
     virtual float magneticFieldSampleRate(); // Sampling rate of the sensor.
 
-    float getTemperature();
-
   protected:
     // can be modified by subclassing for finer configuration
     virtual int8_t configure_sensor(struct bmm150_dev *dev);


### PR DESCRIPTION
This fixes #27.

Hi @simonmicro, you're right, the function is not implemented ...

At first I though this would be quick to fix, but the more I dived into the existing library the more roadblocks I encountered.

The main issue is that this library is built around a sensor interface library provided by Bosch ([BMI270-Sensor-API](https://github.com/boschsensortec/BMI270-Sensor-API)). And while the sensor provides a temperature sensor and it would be relatively easy to bypass the Bosch interface library to directly read it out doing so could create problems down the road (since then there would be direct chip access bypassing the Bosch interface library). Extending the Bosch interface library would have been the option, but boy is that one tailored for a specific use case. Given that I have neither the time nor the mandate to do this I'm going with the easiest option - removing the misleading prototype so that future users do not fall into the same trap.