### PR TITLE
Limit advised architecture support to `samd`, `mbed_portenta`, `mbed_nano`, `mbed_edge`, `esp32` and `rp2040`.

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Allows you to read the accelerometer, magnetometer and gyroscope values
 paragraph=
 category=Sensors
 url=https://github.com/arduino-libraries/Arduino_BMI270_BMM150
-architectures=*
+architectures=samd,mbed_portenta,mbed_nano,mbed_edge,esp32,rp2040
 includes=Arduino_BMI270_BMM150.h


### PR DESCRIPTION
This should put an end to confusions that come up regularly, i.e. in https://github.com/arduino-libraries/Arduino_BMI270_BMM150/issues/37 .

The architectures `samd`, `mbed_portenta`, `mbed_nano`, `mbed_edge`, `esp32` and `rp2040` are all supported as per successful CI compilation.