### PR TITLE
Fix spell check false positives by ignoring words

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -2,7 +2,7 @@
 # See: https://github.com/codespell-project/codespell#using-a-config-file
 [codespell]
 # In the event of a false positive, add the problematic word, in all lowercase, to a comma-separated list here:
-ignore-words-list = ois,
+ignore-words-list = interruptin,ois,
 skip = ./.git,./.licenses,__pycache__,node_modules,./go.mod,./go.sum,./package-lock.json,./poetry.lock,./yarn.lock
 builtin = clear,informal,en-GB_to_en-US
 check-filenames =


### PR DESCRIPTION
The [**codespell**](https://github.com/codespell-project/codespell) spellchecker tool is used to automatically detect commonly misspelled words in the files of this project.

The misspelled words dictionary was expanded in the [latest release](https://github.com/codespell-project/codespell/releases/tag/v2.3.0) of codespell. Some of the text in the project codebase happens to match against newly added entries, which caused **codespell** to produce false misspelled word detections:

https://github.com/arduino-libraries/Arduino_BMI270_BMM150/actions/runs/9265690392

> spellcheck: src/BMI270.cpp#L8
InterruptIn ==> interrupting, interrupt in, interruption
spellcheck: src/BMI270.cpp#L30
InterruptIn ==> interrupting, interrupt in, interruption

Since the code that produced the detections is correct and intended, the false positives are resolved by [configuring](https://github.com/codespell-project/codespell#using-a-config-file) **codespell** to ignore the problematic word.

