### PR TITLE
Fix spelling mistake in docs/readme.md

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -13,5 +13,5 @@ The ArduinoBMI270_BMM150 library takes care of the sensor initialization and set
 - Accelerometer range is set at ±4 g with a resolution of 0.122 mg.
 - Gyroscope range is set at ±2000 dps with a resolution of 70 mdps.
 - Magnetometer range is set at ±1300 uT with a resolution of 0.3 uT.
-- Accelerometer and gyrospcope output data rate is fixed at 99.84 Hz.
+- Accelerometer and gyroscope output data rate is fixed at 99.84 Hz.
 - Magnetometer output data rate is fixed at 10 Hz.


### PR DESCRIPTION
Fix misspelling of gyroscope as "gyropscope" in docs/readme.md.