### PR TITLE
feat: expose advanced power save config to enable high ODR

### DIFF
--- a/src/BMI270.cpp
+++ b/src/BMI270.cpp
@@ -142,6 +142,21 @@ void BoschSensorClass::oneShotMode() {
   continuousMode.end();
 }
 
+// default value is 1 (aps_on). power saving may prevent high odr setting to work properly
+bool BoschSensorClass::setAdvPowerSaveMode(uint8_t enable)
+{
+  int8_t rslt = bmi2_set_adv_power_save(enable ? BMI2_ENABLE : BMI2_DISABLE, &bmi2);
+  return (rslt == BMI2_OK);
+}
+
+uint8_t BoschSensorClass::getAdvPowerSaveMode()
+{
+  uint8_t status = 0;
+  if(bmi2_get_adv_power_save(&status, &bmi2) == BMI2_OK) {
+    return status;
+  }
+  return 0;
+}
 // default range is +-4G, so conversion factor is (((1 << 15)/4.0f))
 #define INT16_to_G   (8192.0f)
 

--- a/src/BMI270.cpp
+++ b/src/BMI270.cpp
@@ -143,13 +143,13 @@ void BoschSensorClass::oneShotMode() {
 }
 
 // default value is 1 (aps_on). power saving may prevent high odr setting to work properly
-bool BoschSensorClass::setAdvPowerSaveMode(uint8_t enable)
+bool BoschSensorClass::setAdvancedPowerSaveMode(uint8_t enable)
 {
   int8_t rslt = bmi2_set_adv_power_save(enable ? BMI2_ENABLE : BMI2_DISABLE, &bmi2);
   return (rslt == BMI2_OK);
 }
 
-uint8_t BoschSensorClass::getAdvPowerSaveMode()
+uint8_t BoschSensorClass::getAdvancedPowerSaveMode()
 {
   uint8_t status = 0;
   if(bmi2_get_adv_power_save(&status, &bmi2) == BMI2_OK) {

--- a/src/BoschSensorClass.h
+++ b/src/BoschSensorClass.h
@@ -135,7 +135,8 @@ class BoschSensorClass {
 
     void setContinuousMode();
     void oneShotMode();
-
+    bool setAdvPowerSaveMode(uint8_t enable);
+    uint8_t getAdvPowerSaveMode();
     int begin(CfgBoshSensor_t cfg = BOSCH_ACCEL_AND_MAGN);
     void end();
 

--- a/src/BoschSensorClass.h
+++ b/src/BoschSensorClass.h
@@ -135,8 +135,8 @@ class BoschSensorClass {
 
     void setContinuousMode();
     void oneShotMode();
-    bool setAdvPowerSaveMode(uint8_t enable);
-    uint8_t getAdvPowerSaveMode();
+    bool setAdvancedPowerSaveMode(uint8_t enable);
+    uint8_t getAdvancedPowerSaveMode();
     int begin(CfgBoshSensor_t cfg = BOSCH_ACCEL_AND_MAGN);
     void end();
 


### PR DESCRIPTION
### Problem
One of the cause of low odr in #25 was from having advanced power saving mode ON by default
### Solution
Expose bmi2_set_adv_power_save to BoschSensorClass to allow disabling
(Also, expose bmi2_get_adv_power_save for convenience)
### Test Result
By disabling advanced power saving, I could achieve up to 800Hz (with wire clock set to 400KHz)
Tested on nano ble 33 sense rev2