### PR TITLE
Fix IMU coordinate frame (LHS -> RHS)

### DIFF
--- a/src/BMI270.cpp
+++ b/src/BMI270.cpp
@@ -157,8 +157,8 @@ int BoschSensorClass::readAcceleration(float& x, float& y, float& z) {
   }
 
   #ifdef TARGET_ARDUINO_NANO33BLE
-  x = -sensor_data.acc.y / INT16_to_G;
-  y = -sensor_data.acc.x / INT16_to_G;
+  x = sensor_data.acc.x / INT16_to_G;
+  y = sensor_data.acc.y / INT16_to_G;
   #else
   x = sensor_data.acc.x / INT16_to_G;
   y = sensor_data.acc.y / INT16_to_G;
@@ -200,8 +200,8 @@ int BoschSensorClass::readGyroscope(float& x, float& y, float& z) {
     ret = bmi2_get_sensor_data(&sensor_data, &bmi2);
   }
   #ifdef TARGET_ARDUINO_NANO33BLE
-  x = -sensor_data.gyr.y / INT16_to_DPS;
-  y = -sensor_data.gyr.x / INT16_to_DPS;
+  x = sensor_data.gyr.x / INT16_to_DPS;
+  y = sensor_data.gyr.y / INT16_to_DPS;
   #else
   x = sensor_data.gyr.x / INT16_to_DPS;
   y = sensor_data.gyr.y / INT16_to_DPS;


### PR DESCRIPTION
# Summary
This PR fixes an incorrect axis remapping applied to the Arduino Nano 33 BLE Sense Rev2 in the Arduino_BMI270_BMM150 library. Starting from v1.1.0, a Rev1 specific X/Y swap with negation is applied unconditionally when ```TARGET_ARDUINO_NANO33BLE``` is defined. While this remap is required for the original Nano 33 BLE Sense (Rev1), it produces incorrect accelerometer and gyroscope axes on Rev2 hardware, where the BMI270 sensor’s native axes already align with the PCB coordinate frame. This change restores physically correct axis alignment on Rev2 by removing the unnecessary swap and negation, while preserving the existing scaling to physical units.
# Background
Starting from library version **v1.1.0**, the accelerometer and gyroscope outputs for **TARGET_ARDUINO_NANO33BLE** are remapped as follows:
```
x = -sensor_data.*.y;
y = -sensor_data.*.x;
z =  sensor_data.*.z;
```
This remapping was introduced to correct the **sensor mounting orientation** on the original **Nano 33 BLE Sense (Rev1)**, where the BMI270 is rotated relative to the PCB coordinate frame.
However, on the **Nano 33 BLE Sense Rev2**, the BMI270 sensor is mounted such that its native **axes already align with the PCB axis markings**. Applying the Rev1 remap on Rev2 therefore results in:
- X and Y axes being swapped
- Incorrect physical interpretation of acceleration and angular velocity
- Confusing gravity and rotation tests (e.g., gravity appearing on the wrong axis)
# Root Cause
- The remapping logic is guarded only by TARGET_ARDUINO_NANO33BLE
- There is no distinction between Rev1 and Rev2 hardware
- The same transform is applied to both revisions, despite different sensor orientations
- As a result, a remap that is required for Rev1 is incorrect for Rev2.

# Changes Introduced
### Accelerometer (```readAcceleration```)
- Removed X/Y swap
- Removed unnecessary negation
- Preserved scaling to physical units (g)

**Before:**
```
x = -sensor_data.acc.y / INT16_to_G;
y = -sensor_data.acc.x / INT16_to_G;
z =  sensor_data.acc.z / INT16_to_G;
```
**After:**
```
x =  sensor_data.acc.x / INT16_to_G;
y =  sensor_data.acc.y / INT16_to_G;
z =  sensor_data.acc.z / INT16_to_G;
```
### Gyroscope (```readGyroscope```)
- Applied the same correction for consistency with the accelerometer
- Preserved scaling to degrees per second
**Before:**
```
x = -sensor_data.gyr.y / INT16_to_DPS;
y = -sensor_data.gyr.x / INT16_to_DPS;
z =  sensor_data.gyr.z / INT16_to_DPS;
```
**After:**
```
x =  sensor_data.gyr.x / INT16_to_DPS;
y =  sensor_data.gyr.y / INT16_to_DPS;
z =  sensor_data.gyr.z / INT16_to_DPS;
```
# Verification / Testing
The fix was validated using **static gravity tests**, which provide a reliable ground truth:
- With the board stationary and each PCB axis aligned with gravity:
  - +X up -> X ~ +1 g
  - +Y up -> Y ~ +1 g
  - +Z up -> Z ~ +1 g
- Gyroscope signs were consistent with right-hand rule rotations
- Behavior now matches library version v1.0.0 geometry, while retaining correct scaling
- These tests confirm that:
  - Axis directions match PCB markings
  - The coordinate system is physically correct
  - No unintended sign inversions remain

> **Note:** This PR focuses on restoring correct behavior for Nano 33 BLE Sense Rev2. A future improvement could explicitly distinguish Rev1 and Rev2 hardware and apply revision-specific remapping where required.