### PR TITLE
feat: Add readAccelerationGyroscope for combined sensor reads to improve performance

### DIFF
--- a/src/BMI270.cpp
+++ b/src/BMI270.cpp
@@ -229,6 +229,39 @@ float BoschSensorClass::gyroscopeSampleRate() {
   return (1 << sens_cfg.cfg.gyr.odr) * 0.39;
 }
 
+// Read both Accel and Gyro in one bmi2_get_sensor_data call
+int BoschSensorClass::readAccelerationGyroscope(float& ax, float& ay, float& az, float& gx, float& gy, float& gz) {
+  struct bmi2_sens_data sensor_data;
+  int ret = 0;
+
+  if (continuousMode.hasData(BMI270_ACCELEROMETER) && continuousMode.hasData(BMI270_GYROSCOPE)) {
+    continuousMode.getAccelerometerData(&sensor_data.acc);
+    continuousMode.getGyroscopeData(&sensor_data.gyr);
+  } else {
+    ret = bmi2_get_sensor_data(&sensor_data, &bmi2);
+  }
+
+  #ifdef TARGET_ARDUINO_NANO33BLE
+  ax = -sensor_data.acc.y / INT16_to_G;
+  ay = -sensor_data.acc.x / INT16_to_G;
+  #else
+  ax = sensor_data.acc.x / INT16_to_G;
+  ay = sensor_data.acc.y / INT16_to_G;
+  #endif
+  az = sensor_data.acc.z / INT16_to_G;
+
+  #ifdef TARGET_ARDUINO_NANO33BLE
+  gx = -sensor_data.gyr.y / INT16_to_DPS;
+  gy = -sensor_data.gyr.x / INT16_to_DPS;
+  #else
+  gx = sensor_data.gyr.x / INT16_to_DPS;
+  gy = sensor_data.gyr.y / INT16_to_DPS;
+  #endif
+  gz = sensor_data.gyr.z / INT16_to_DPS;
+
+  return (ret == 0);
+}
+
 // Magnetometer
 int BoschSensorClass::readMagneticField(float& x, float& y, float& z) {
   struct bmm150_mag_data mag_data;

--- a/src/BoschSensorClass.h
+++ b/src/BoschSensorClass.h
@@ -171,6 +171,9 @@ class BoschSensorClass {
     virtual int gyroscopeAvailable(); // Number of samples in the FIFO.
     virtual float gyroscopeSampleRate(); // Sampling rate of the sensor.
 
+    // Accelerometer & Gyroscope
+    virtual int readAccelerationGyroscope(float& ax, float& ay, float& az, float& gx, float& gy, float& gz);
+
     // Magnetometer
     virtual int readMagneticField(float& x, float& y, float& z); // Results are in uT (micro Tesla).
     virtual int magneticFieldAvailable(); // Number of samples in the FIFO.


### PR DESCRIPTION
### Problem
As mentioned in #50, the actual sampling rate drops when reading acceleration and gyroscope at the same time.

### Solution
Since `ret = bmi2_get_sensor_data(&sensor_data, &bmi2)` called in both `readAcceleration` and `readGyroscope` already read all sensors data. Calling it seperatedly in both method is redundant.
I implemented `readAccelerationGyroscope` that calculates `ax, ay, az, gx, gy, gz` in one `bmi2_get_sensor_data` call to reduce the overhead.

### Test Result
Tested on Arduino Nano 33 BLE Sense Rev2.
calling: 
`IMU.readAccelerationGyroscope(ax, ay, az, gx, gy, gz)`
instead of:
`IMU.readAcceleration(ax, ay, az);`
`IMU.readGyroscope(gx, gy, gz);`
improved the actual sampling rate by almost double.